### PR TITLE
Remove appindicator as mandatory dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,38 +2,41 @@
 # Project Gnome-Pie
 ################################################################
 
- project("gnomepie" C)
- 
- cmake_minimum_required(VERSION 2.6)
- 
- # Location where cmake first looks for modules.
- list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/vala)
+project("gnomepie" C)
+
+cmake_minimum_required(VERSION 2.6)
+
+# Location where cmake first looks for modules.
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/vala)
 
 ################################################################
 # Find Vala
 ################################################################
 
-include(ValaPrecompile) 
+include(ValaPrecompile)
 include(ValaVersion)
 
-find_package(Vala) 
+find_package(Vala)
 ensure_vala_version("0.11.0" MINIMUM)
 
 ################################################################
 # Configure and find libraries
 ################################################################
 
-find_package(PkgConfig) 
-pkg_check_modules(GTK REQUIRED gtk+-2.0) 
-pkg_check_modules(CAIRO REQUIRED cairo) 
+find_package(PkgConfig)
+pkg_check_modules(GIO REQUIRED gio-unix-2.0)
+pkg_check_modules(GTK REQUIRED gtk+-2.0)
+pkg_check_modules(CAIRO REQUIRED cairo)
 pkg_check_modules(GEE REQUIRED gee-1.0)
 pkg_check_modules(X11 REQUIRED x11)
-pkg_check_modules(INDICATOR REQUIRED appindicator-0.1)
+pkg_check_modules(INDICATOR appindicator-0.1)
 pkg_check_modules(XML REQUIRED libxml-2.0)
 pkg_check_modules(XTST REQUIRED xtst)
 pkg_check_modules(GMENU REQUIRED libgnome-menu)
 
+# TODO if here
 set(CFLAGS
+  ${GIO_CFLAGS}
 	${GTK_CFLAGS} ${GTK_CFLAGS_OTHER}
 	${CAIRO_CFLAGS} ${CAIRO_CFLAGS_OTHER}
 	${GEE_CFLAGS} ${CAIRO_CFLAGS_OTHER}
@@ -41,12 +44,13 @@ set(CFLAGS
 	-DGMENU_I_KNOW_THIS_IS_UNSTABLE
     # for gettext
     -DGETTEXT_PACKAGE="gnomepie"
-	-s -O3 
+	-s -O3
 #    -g
 )
 add_definitions(${CFLAGS})
 
 set(LIBS
+  ${GIO_LIBRARIES}
 	${GTK_LIBRARIES}
 	${CAIRO_LIBRARIES}
 	${GEE_LIBRARIES}
@@ -84,6 +88,23 @@ include_directories(${INCLUDE_PATHS})
 ################################################################
 
 set(EXECUTABLE_OUTPUT_PATH ${gnomepie_SOURCE_DIR})
+
+
+##
+set(VALA_PKGS
+  gtk+-2.0
+  gdk-x11-2.0
+  cairo
+  gee-1.0
+  x11
+  gio-unix-2.0
+  posix
+  libxml-2.0
+  xtst
+  libgnome-menu
+)
+
+LIST(APPEND CFLAGS -DHAVE_APPINDICATOR)
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,25 +5,20 @@
 # determine source and header files
 file(GLOB VALA_SRC RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.vala */*.vala)
 
+if (${INDICATOR_FOUND})
+  SET(DEFINES --define HAVE_APPINDICATOR)
+endif(${INDICATOR_FOUND})
+
 # use valac to compile sources to c files
 vala_precompile(
     VALA_C
-        ${VALA_SRC} 
-    PACKAGES 
-        appindicator-0.1
-        gtk+-2.0 
-        gdk-x11-2.0 
-        cairo 
-        gee-1.0
-        x11
-        gio-unix-2.0
-        posix
-        libxml-2.0
-        xtst
-        libgnome-menu
+        ${VALA_SRC}
+    PACKAGES
+        ${VALA_PKGS}
     OPTIONS
         --vapidir=${CMAKE_SOURCE_DIR}/vapi/
         --thread
+        ${DEFINES}
 )
 
 # compile c-sources
@@ -31,7 +26,7 @@ add_executable(gnome-pie ${VALA_C})
 
 # install executable
 install(
-	TARGETS 
+	TARGETS
 		gnome-pie
 	RUNTIME DESTINATION
 		${CMAKE_INSTALL_PREFIX}/bin
@@ -47,9 +42,9 @@ install(
 
 # install locales
 install(
-	DIRECTORY 
+	DIRECTORY
 		${CMAKE_SOURCE_DIR}/resources/locale
-	DESTINATION 
+	DESTINATION
 		${CMAKE_INSTALL_PREFIX}/share
 	PATTERN *.po EXCLUDE
 	PATTERN *.pot EXCLUDE
@@ -58,9 +53,9 @@ install(
 
 # install themes
 install(
-	DIRECTORY 
+	DIRECTORY
 		${CMAKE_SOURCE_DIR}/resources/themes
-	DESTINATION 
+	DESTINATION
 		${CMAKE_INSTALL_PREFIX}/share/gnome-pie
 )
 

--- a/src/gui/indicator.vala
+++ b/src/gui/indicator.vala
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2011 by Simon Schneegans
 
 This program is free software: you can redistribute it and/or modify it
@@ -12,12 +12,12 @@ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
 more details.
 
 You should have received a copy of the GNU General Public License along with
-this program.  If not, see <http://www.gnu.org/licenses/>. 
+this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 namespace GnomePie {
 
-/////////////////////////////////////////////////////////////////////////    
+/////////////////////////////////////////////////////////////////////////
 /// An appindicator sitting in the panel. It owns the settings menu.
 /////////////////////////////////////////////////////////////////////////
 
@@ -27,33 +27,47 @@ public class Indicator : GLib.Object {
     /// The internally used indicator.
     /////////////////////////////////////////////////////////////////////
 
+#if HAVE_APPINDICATOR
     private AppIndicator.Indicator indicator { private get; private set; }
-    
+#else
+    private Gtk.StatusIcon indicator {private get; private set; }
+    private Gtk.Menu menu {private get; private set; }
+#endif
+
     /////////////////////////////////////////////////////////////////////
     /// The Preferences Menu of Gnome-Pie.
     /////////////////////////////////////////////////////////////////////
-    
-    private Preferences prefs { private get; private set; } 
-    
+
+    private Preferences prefs { private get; private set; }
+
     /////////////////////////////////////////////////////////////////////
     /// Returns true, when the indicator is currently visible.
     /////////////////////////////////////////////////////////////////////
-    
+
     public bool active {
         get {
+#if HAVE_APPINDICATOR
             return indicator.get_status() == AppIndicator.IndicatorStatus.ACTIVE;
+#else
+            return indicator.get_visible();
+#endif
         }
         set {
+#if HAVE_APPINDICATOR
             if (value) indicator.set_status(AppIndicator.IndicatorStatus.ACTIVE);
             else       indicator.set_status(AppIndicator.IndicatorStatus.PASSIVE);
+#else
+            indicator.set_visible(value);
+#endif
         }
     }
-    
+
     /////////////////////////////////////////////////////////////////////
     /// C'tor, constructs a new Indicator, residing in the user's panel.
     /////////////////////////////////////////////////////////////////////
-    
+
     public Indicator() {
+#if HAVE_APPINDICATOR
         string path = "";
         string icon = "indicator-applet";
         try {
@@ -63,18 +77,32 @@ public class Indicator : GLib.Object {
             warning("Failed to get path of executable!");
         }
 
-        this.indicator = new AppIndicator.Indicator.with_path("Gnome-Pie", icon, 
+        this.indicator = new AppIndicator.Indicator.with_path("Gnome-Pie", icon,
                              AppIndicator.IndicatorCategory.APPLICATION_STATUS, path);
-        this.prefs = new Preferences();
-        
         var menu = new Gtk.Menu();
+#else
+        this.indicator = new Gtk.StatusIcon();
+        try {
+            this.indicator.set_from_file(GLib.Path.build_filename(
+                GLib.Path.get_dirname(GLib.FileUtils.read_link("/proc/self/exe"))+"/resources",
+                "gnome-pie-indicator.svg"
+            ));
+        } catch (GLib.FileError e) {
+            warning("Failed to get path of executable!");
+            this.indicator.set_from_stock(Gtk.Stock.HOME); // or suitable stock
+        }
+
+        this.menu = new Gtk.Menu();
+        var menu = this.menu;
+#endif
+        this.prefs = new Preferences();
 
         // preferences item
         var item = new Gtk.ImageMenuItem.from_stock (Gtk.Stock.PREFERENCES, null);
         item.activate.connect(() => {
             this.prefs.show();
         });
-        
+
         item.show();
         menu.append(item);
 
@@ -87,7 +115,7 @@ public class Indicator : GLib.Object {
             about.destroy();
         });
         menu.append(item);
-        
+
         // separator
         var sepa = new Gtk.SeparatorMenuItem();
         sepa.show();
@@ -99,18 +127,24 @@ public class Indicator : GLib.Object {
         item.show();
         menu.append(item);
 
+#if HAVE_APPINDICATOR
         this.indicator.set_menu(menu);
-        
+#else
+        this.indicator.popup_menu.connect((btn, time) => {
+            this.menu.popup(null, null, null, btn, time);
+        });
+#endif
+
         this.active = Config.global.show_indicator;
         Config.global.notify["show-indicator"].connect((s, p) => {
             this.active = Config.global.show_indicator;
         });
     }
-    
+
     /////////////////////////////////////////////////////////////////////
     /// Shows the preferences menu.
     /////////////////////////////////////////////////////////////////////
-    
+
     public void show_preferences() {
         this.prefs.show();
     }


### PR DESCRIPTION
This should remove the mandatory dependency on appindicator and make it optional for distribution which do not support it. Give it a try!
