### PR TITLE
Bugfix: bad mouse binding warning

### DIFF
--- a/src/gui/triggerSelectWindow.vala
+++ b/src/gui/triggerSelectWindow.vala
@@ -192,7 +192,7 @@ public class TriggerSelectWindow : Gtk.Dialog {
         Gdk.ModifierType state = event.state & ~ this.lock_modifiers;
         var new_trigger = new Trigger.from_values((int)event.button, state, true, 
                                                   this.turbo.active, this.delayed.active);
-        if (new_trigger.name.contains("button1")) {
+        if (new_trigger.key_code == 1) {
             var dialog = new Gtk.MessageDialog((Gtk.Window)this.get_toplevel(), Gtk.DialogFlags.MODAL, 
                                                 Gtk.MessageType.WARNING, 
                                                 Gtk.ButtonsType.YES_NO, 


### PR DESCRIPTION
The application warned the user about the danger of binding the left mouse button even when the chosen button number was different from 1. I have a mouse with many buttons, and it warned me with the same message for every button >= 10.
It was because of a string comparison. Please have a look at my fix.
