### PR TITLE
Fix real transparency on gnome 3.10

### DIFF
--- a/src/renderers/pieWindow.vala
+++ b/src/renderers/pieWindow.vala
@@ -85,6 +85,7 @@ public class PieWindow : Gtk.Window {
         this.set_resizable(false);
         this.icon_name = "gnome-pie";
         this.set_accept_focus(false);
+        this.app_paintable = true;
         
         // check for compositing
         if (this.screen.is_composited()) {


### PR DESCRIPTION
Simply putting "app_paintable" property to true on the pie window gave me (real) transparency back.

Tested with archlinux (gnome-shell 3.10.3).
