### PR TITLE
Limit the number of shown slices: auto-hide some of them + scroll.

### DIFF
--- a/src/renderers/centerRenderer.vala
+++ b/src/renderers/centerRenderer.vala
@@ -94,7 +94,7 @@ public class CenterRenderer : GLib.Object {
     /// Draws all center layers and the caption.
     /////////////////////////////////////////////////////////////////////
     
-    public void draw(double frame_time, Cairo.Context ctx, double angle, int mouse_track) {
+    public void draw(double frame_time, Cairo.Context ctx, double angle, int slice_track) {
         // get all center_layers
 	    var layers = Config.global.theme.center_layers;
         

--- a/src/renderers/pieRenderer.vala
+++ b/src/renderers/pieRenderer.vala
@@ -507,12 +507,12 @@ public class PieRenderer : GLib.Object {
         if (this.size_w > 0) {
 	        double distance = sqrt(mouse_x*mouse_x + mouse_y*mouse_y);
 	        double angle = 0.0;
-	        int mouse_track= 0;
+	        int slice_track= 0;
 
 	        if (this.key_board_control) {
 	            int n= this.active_slice - this.first_slice_idx;
 	            angle = 2.0*PI*n/(double)this.total_slice_count + this.first_slice_angle;
-	            mouse_track= 1;
+	            slice_track= 1;
 	        } else {
 
 	            if (distance > 0) {
@@ -541,7 +541,7 @@ public class PieRenderer : GLib.Object {
     	                next_active_slice = -1;
     	            else {
 	                    next_active_slice = next_active_slice + this.first_slice_idx;
-	                    mouse_track= 1;
+	                    slice_track= 1;
 	                }
 	            } else {
 	                next_active_slice = -1;
@@ -550,11 +550,11 @@ public class PieRenderer : GLib.Object {
 	            this.set_highlighted_slice(next_active_slice);
 	        }
 
-            center.draw(frame_time, ctx, angle, mouse_track);
+            center.draw(frame_time, ctx, angle, slice_track);
 
 	        //foreach (var slice in this.slices)
 	        for (int i= 0; i < this.visible_slice_count; ++i) {
-	           this.slices[ i+this.first_slice_idx ].draw(frame_time, ctx, angle, mouse_track);
+	           this.slices[ i+this.first_slice_idx ].draw(frame_time, ctx, angle, slice_track);
 		    }
 		}
     }

--- a/src/renderers/pieRenderer.vala
+++ b/src/renderers/pieRenderer.vala
@@ -49,7 +49,90 @@ public class PieRenderer : GLib.Object {
     /// The width and height of the Pie in pixels.
     /////////////////////////////////////////////////////////////////////
 
-    public int size { get; private set; }
+    public int size_w { get; private set; }
+    public int size_h { get; private set; }
+
+    /////////////////////////////////////////////////////////////////////
+    /// Center position relative to window top-left corner
+    /////////////////////////////////////////////////////////////////////
+
+    public int center_x { get; private set; }
+    public int center_y { get; private set; }
+
+
+    ////////////////////////////////////////////////////////////////////
+    /// Possible show pie modes.
+    /// FULL_PIE:       Show the pie as a complete circle.
+    /// HPIE_LEFT:      Eat half pie so it can be shown at the left of the screen.
+    /// HPIE_RIGHT:     Eat half pie so it can be shown at the right of the screen.
+    /// HPIE_TOP:       Eat half pie so it can be shown at the top of the screen.
+    /// HPIE_BOTTOM:    Eat half pie so it can be shown at the bottom of the screen.
+    /// CPIE_TOP_LEFT:  Eat  3/4 pie so it can be shown at the top-left corner.
+    /// CPIE_TOP_RIGHT: Eat  3/4 pie so it can be shown at the top-right corner.
+    /// CPIE_BOT_LEFT:  Eat  3/4 pie so it can be shown at the bottom-left corner.
+    /// CPIE_BOT_RIGHT: Eat  3/4 pie so it can be shown at the bottom-right corner.
+    /////////////////////////////////////////////////////////////////////
+
+    public enum ShowPieMode {FULL_PIE, 
+                    HPIE_LEFT, HPIE_RIGHT, HPIE_TOP, HPIE_BOTTOM, 
+                    CPIE_TOP_LEFT, CPIE_TOP_RIGHT, CPIE_BOT_LEFT, CPIE_BOT_RIGHT}
+    
+    /////////////////////////////////////////////////////////////////////
+    ///  Show pie mode: full, half-circle, corner
+    /////////////////////////////////////////////////////////////////////
+
+    public ShowPieMode pie_show_mode { get; private set; }
+    
+    /////////////////////////////////////////////////////////////////////
+    /// True if the pie will change the show mode depending on mouse position
+    /// (eat some pie to show the center near the mouse)
+    /////////////////////////////////////////////////////////////////////
+
+    public bool auto_show_pie_mode { get; private set; default=false; }
+
+
+    /////////////////////////////////////////////////////////////////////
+    /// Number of visible slices
+    /////////////////////////////////////////////////////////////////////
+
+    public int visible_slice_count { get; private set; }
+    
+    public int original_visible_slice_count { get; private set; }
+
+    /////////////////////////////////////////////////////////////////////
+    /// Number of slices in full pie (visible or not)
+    /////////////////////////////////////////////////////////////////////
+
+    public int total_slice_count { get; private set; }
+
+	/////////////////////////////////////////////////////////////////////
+    /// Maximun number of visible slices in a full pie
+    /////////////////////////////////////////////////////////////////////
+
+    public int max_visible_slices { get; private set; }
+
+    /////////////////////////////////////////////////////////////////////
+    /// The index of the first visible slice 
+    /////////////////////////////////////////////////////////////////////
+
+    public int first_slice_idx { get; private set; }
+
+    /////////////////////////////////////////////////////////////////////
+    /// Angular position of the first visible slice 
+    /////////////////////////////////////////////////////////////////////
+
+    public double first_slice_angle { get; private set; }
+
+    /////////////////////////////////////////////////////////////////////
+    /// Index of the slice where to go when up/down/left/right key is pressed
+    /// or -1 if that side of the pie was eaten
+    /////////////////////////////////////////////////////////////////////
+
+    public int up_slice_idx { get; private set; }
+    public int down_slice_idx { get; private set; }
+    public int left_slice_idx { get; private set; }
+    public int right_slice_idx { get; private set; }
+
 
     /////////////////////////////////////////////////////////////////////
     /// True if the pie should close when it's trigger is released.
@@ -85,9 +168,41 @@ public class PieRenderer : GLib.Object {
         this.center = new CenterRenderer(this);
         this.quickaction = -1;
         this.active_slice = -2;
-        this.size = 0;
+        this.size_w = 0;
+        this.size_h = 0;
+        
+        this.max_visible_slices= 24;
+        
+        this.auto_show_pie_mode= true; //eat some pie to show the center near the mouse
+        
+        set_show_mode(ShowPieMode.FULL_PIE);
     }
 
+   
+    private void get_mouse_and_screen(out int mousex, out int mousey, out int screenx, out int screeny) {
+        // get the mouse position and screen resolution
+        double x = 0.0;
+        double y = 0.0;
+        
+        //screenx= 0;
+        //screeny= 0;
+
+        var display = Gdk.Display.get_default();
+        var manager = display.get_device_manager();
+        GLib.List<weak Gdk.Device?> list = manager.list_devices(Gdk.DeviceType.MASTER);
+
+        foreach(var device in list) {
+            if (device.input_source != Gdk.InputSource.KEYBOARD) {
+                Gdk.Screen screen;
+                device.get_position( out screen, out x, out y );
+            }
+        }
+        mousex= (int) x;
+        mousey= (int) y;
+        screenx= Gdk.Screen.width();
+        screeny= Gdk.Screen.height();
+    }
+    
     /////////////////////////////////////////////////////////////////////
     /// Loads a Pie. All members are initialized accordingly.
     /////////////////////////////////////////////////////////////////////
@@ -114,15 +229,124 @@ public class PieRenderer : GLib.Object {
 
         this.set_highlighted_slice(this.quickaction);
 
-        this.size = (int)fmax(2*Config.global.theme.radius + 2*Config.global.theme.slice_radius*Config.global.theme.max_zoom,
-                              2*Config.global.theme.center_radius);
 
+        //set full pie to determine the number of visible slices
+	    set_show_mode(ShowPieMode.FULL_PIE);
+
+        int sz0= (int)fmax(2*Config.global.theme.radius + 2*Config.global.theme.slice_radius*Config.global.theme.max_zoom,
+                              2*Config.global.theme.center_radius);
+		
+		int sz= sz0;
         // increase size if there are many slices
-        if (slices.size > 0) {
-            this.size = (int)fmax(this.size,
-                (((Config.global.theme.slice_radius + Config.global.theme.slice_gap)/tan(PI/slices.size))
+        if (this.total_slice_count > 0) {
+            sz = (int)fmax(sz0,
+                (((Config.global.theme.slice_radius + Config.global.theme.slice_gap)/tan(PI/this.total_slice_count))
                 + Config.global.theme.slice_radius)*2*Config.global.theme.max_zoom);
         }
+        
+
+        if (this.auto_show_pie_mode) {
+            // get mouse position and screen resolution
+            int mouse_x, mouse_y, screen_x, screen_y;
+            get_mouse_and_screen( out mouse_x, out mouse_y, out screen_x, out screen_y );
+            //set the best show mode that put the mouse near the center
+            if (mouse_x < sz/2) {
+                if (mouse_y < sz/2)
+                    set_show_mode(ShowPieMode.CPIE_TOP_LEFT);   //show 1/4 pie
+                else if (screen_y > 0 && screen_y-mouse_y < sz/2)
+                    set_show_mode(ShowPieMode.CPIE_BOT_LEFT);   //show 1/4 pie
+                else
+                    set_show_mode(ShowPieMode.HPIE_LEFT);       //show 1/2 pie
+                    
+            } else if (mouse_y < sz/2) {
+                if (screen_x > 0 && screen_x-mouse_x < sz/2)
+                    set_show_mode(ShowPieMode.CPIE_TOP_RIGHT);  //show 1/4 pie
+                else
+                    set_show_mode(ShowPieMode.HPIE_TOP);        //show 1/2 pie
+                
+            } else if (screen_x > 0 && screen_x-mouse_x < sz/2) {
+                if (screen_y > 0 && screen_y-mouse_y < sz/2) 
+                    set_show_mode(ShowPieMode.CPIE_BOT_RIGHT);  //show 1/4 pie
+                else
+                    set_show_mode(ShowPieMode.HPIE_RIGHT);      //show 1/2 pie
+
+            } else if (screen_y > 0 && screen_y-mouse_y < sz/2)
+                set_show_mode(ShowPieMode.HPIE_BOTTOM);         //show 1/2 pie
+           
+
+        //} else {            
+        //    //select a fixed show mode (can be configurable by GUI)
+		//    set_show_mode(ShowPieMode.FULL_PIE);
+		}
+
+        //recalc size            
+	    sz= sz0;
+        if (this.total_slice_count > 0) {
+            sz = (int)fmax(sz0,
+                (((Config.global.theme.slice_radius + Config.global.theme.slice_gap)/tan(PI/this.total_slice_count))
+                + Config.global.theme.slice_radius)*2*Config.global.theme.max_zoom);
+        }
+
+        int szx= 1; //full width
+        int szy= 1; //full height
+        switch(this.pie_show_mode) {
+    	    //half pie
+            case ShowPieMode.HPIE_LEFT:
+                szx= 0; //half width, center to the left
+                break;
+            case ShowPieMode.HPIE_RIGHT:
+                szx= 2; //half width, center to the right
+                break;
+            case ShowPieMode.HPIE_TOP:
+                szy= 0; //half height, center to the top
+                break;
+            case ShowPieMode.HPIE_BOTTOM:
+                szy= 2; //half height, center to the bottom
+                break;
+
+            //cuarter pie
+            case ShowPieMode.CPIE_TOP_LEFT:
+                szx= 0; //half width, center to the left
+                szy= 0; //half height, center to the top
+                break;
+            case ShowPieMode.CPIE_TOP_RIGHT:
+                szx= 2; //half width, center to the right
+                szy= 0; //half height, center to the top
+                break;
+            case ShowPieMode.CPIE_BOT_LEFT:
+                szx= 0; //half width, center to the left
+                szy= 2; //half height, center to the bottom
+                break;
+            case ShowPieMode.CPIE_BOT_RIGHT:
+                szx= 2; //half width, center to the right
+                szy= 2; //half height, center to the bottom
+                break;
+        }
+        int rc= (int)Config.global.theme.center_radius;
+        if (szx == 1 ) {
+            //full width
+            this.size_w= sz;
+    		this.center_x= sz/2;	//center position
+    	} else {
+            //half width
+            this.size_w= sz/2 + rc;
+            if (szx == 0)
+        		this.center_x= rc;	//center to the left
+        	else
+        	    this.center_x= this.size_w-rc;	//center to the right
+    	}
+    	if (szy == 1) {
+            //full heigth
+            this.size_h= sz;
+    		this.center_y= sz/2;	//center position
+    	} else {
+            //half heigth
+            this.size_h= sz/2 + rc;
+            if (szy == 0)
+        		this.center_y= rc;	//center to the top
+        	else
+        	    this.center_y= this.size_h-rc;	//center to the bottom
+    	}
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -130,12 +354,16 @@ public class PieRenderer : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void activate() {
-        if (this.active_slice >= 0 && this.active_slice < this.slices.size) {
+        if (this.active_slice >= this.first_slice_idx 
+            && this.active_slice < this.first_slice_idx+this.visible_slice_count) {
             slices[active_slice].activate();
         }
 
-        foreach (var slice in this.slices)
-            slice.fade_out();
+        //foreach (var slice in this.slices)
+        //    slice.fade_out();
+        for (int i= 0; i < this.visible_slice_count; ++i) {
+	        this.slices[ i+this.first_slice_idx ].fade_out();
+		}
 
         center.fade_out();
     }
@@ -145,29 +373,23 @@ public class PieRenderer : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void cancel() {
-        foreach (var slice in this.slices)
-            slice.fade_out();
+        //foreach (var slice in this.slices)
+        //    slice.fade_out();
+        for (int i= 0; i < this.visible_slice_count; ++i) {
+	        this.slices[ i+this.first_slice_idx ].fade_out();
+		}
 
         center.fade_out();
     }
 
+ 
     /////////////////////////////////////////////////////////////////////
     /// Called when the up-key is pressed. Selects the next slice towards
     /// the top.
     /////////////////////////////////////////////////////////////////////
 
     public void select_up() {
-        int bottom = this.slice_count()/4;
-        int top = this.slice_count()*3/4;
-
-        if (this.active_slice == -1 || this.active_slice == bottom)
-           this.set_highlighted_slice(top);
-        else if (this.active_slice > bottom && this.active_slice < top)
-           this.set_highlighted_slice(this.active_slice+1);
-        else if (this.active_slice != top)
-           this.set_highlighted_slice((this.active_slice-1+this.slice_count())%this.slice_count());
-
-        this.key_board_control = true;
+        move_active_slice(this.up_slice_idx, this.down_slice_idx);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -176,17 +398,7 @@ public class PieRenderer : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void select_down() {
-        int bottom = this.slice_count()/4;
-        int top = this.slice_count()*3/4;
-
-        if (this.active_slice == -1 || this.active_slice == top)
-           this.set_highlighted_slice(bottom);
-        else if (this.active_slice > bottom && this.active_slice < top)
-           this.set_highlighted_slice(this.active_slice-1);
-        else if (this.active_slice != bottom)
-           this.set_highlighted_slice((this.active_slice+1)%this.slice_count());
-
-        this.key_board_control = true;
+        move_active_slice(this.down_slice_idx, this.up_slice_idx);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -195,17 +407,7 @@ public class PieRenderer : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void select_left() {
-        int left = this.slice_count()/2;
-        int right = 0;
-
-        if (this.active_slice == -1 || this.active_slice == right)
-           this.set_highlighted_slice(left);
-        else if (this.active_slice > left)
-           this.set_highlighted_slice(this.active_slice-1);
-        else if (this.active_slice < left)
-           this.set_highlighted_slice(this.active_slice+1);
-
-        this.key_board_control = true;
+        move_active_slice(this.left_slice_idx, this.right_slice_idx);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -214,19 +416,81 @@ public class PieRenderer : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void select_right() {
-        int left = this.slice_count()/2;
-        int right = 0;
-
-        if (this.active_slice == -1 || this.active_slice == left)
-           this.set_highlighted_slice(right);
-        else if (this.active_slice > left)
-           this.set_highlighted_slice((this.active_slice+1)%this.slice_count());
-        else if (this.active_slice < left && this.active_slice != right)
-           this.set_highlighted_slice((this.active_slice-1+this.slice_count())%this.slice_count());
-
-        this.key_board_control = true;
+        move_active_slice(this.right_slice_idx, this.left_slice_idx);
     }
 
+    /////////////////////////////////////////////////////////////////////
+    /// Called when the page_up-key is pressed. Selects the next 
+    /// group of slices.
+    /////////////////////////////////////////////////////////////////////
+
+    public void select_nextpage() {
+        if (this.first_slice_idx+this.visible_slice_count < slices.size) { 
+            //advance one page
+            this.first_slice_idx += this.visible_slice_count;
+            if (this.first_slice_idx+this.visible_slice_count >= slices.size) { 
+                this.visible_slice_count= slices.size - this.first_slice_idx;
+            }
+            this.reset_sclice_anim();
+            this.set_highlighted_slice(-1);
+            calc_key_navigation_pos();
+            this.key_board_control = true;
+            
+        } else if (this.first_slice_idx > 0) {
+            //go to first page
+            this.first_slice_idx= 0;
+            this.reset_sclice_anim();
+            //recover the original value
+            this.visible_slice_count= this.original_visible_slice_count;
+            this.reset_sclice_anim();
+            this.set_highlighted_slice(-1);
+            calc_key_navigation_pos();
+            this.key_board_control = true;
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////
+    /// Called when the page_down-key is pressed. Selects the previous
+    /// group of slices.
+    /////////////////////////////////////////////////////////////////////
+
+    public void select_prevpage() {
+        if (this.first_slice_idx > 0) {
+            //go back one page
+            //recover the original value
+            this.visible_slice_count= this.original_visible_slice_count;
+            this.first_slice_idx -= this.visible_slice_count;
+            if (this.first_slice_idx < 0) {
+                this.first_slice_idx= 0;
+            }
+            this.reset_sclice_anim();
+            this.set_highlighted_slice(-1);
+            calc_key_navigation_pos();
+            this.key_board_control = true;
+            
+        } else if (this.visible_slice_count < slices.size) {
+            //go to last page
+            int n= slices.size % this.original_visible_slice_count;
+            if (n == 0)
+                //all pages have the same number of slices
+                this.visible_slice_count= this.original_visible_slice_count;
+            else
+                //last page has less slices than previous
+                this.visible_slice_count= n;
+            this.first_slice_idx= slices.size - this.visible_slice_count;
+            this.reset_sclice_anim();
+            this.set_highlighted_slice(-1);
+            calc_key_navigation_pos();
+            this.key_board_control = true;
+        }
+    }
+    
+    private void reset_sclice_anim() {
+        //reset animation values in all the new visible slices
+        for (int i= 0; i < this.visible_slice_count; ++i)
+	        this.slices[ i+this.first_slice_idx ].reset_anim();
+    }
+    
     /////////////////////////////////////////////////////////////////////
     /// Returns the amount of slices in this pie.
     /////////////////////////////////////////////////////////////////////
@@ -240,12 +504,15 @@ public class PieRenderer : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void draw(double frame_time, Cairo.Context ctx, int mouse_x, int mouse_y) {
-        if (this.size > 0) {
+        if (this.size_w > 0) {
 	        double distance = sqrt(mouse_x*mouse_x + mouse_y*mouse_y);
 	        double angle = 0.0;
+	        int mouse_track= 0;
 
 	        if (this.key_board_control) {
-	            angle = 2.0*PI*this.active_slice/(double)slice_count();
+	            int n= this.active_slice - this.first_slice_idx;
+	            angle = 2.0*PI*n/(double)this.total_slice_count + this.first_slice_angle;
+	            mouse_track= 1;
 	        } else {
 
 	            if (distance > 0) {
@@ -257,12 +524,25 @@ public class PieRenderer : GLib.Object {
 	            int next_active_slice = this.active_slice;
 
 	            if (distance < Config.global.theme.active_radius
-	                && this.quickaction >= 0 && this.quickaction < this.slices.size) {
+	                && this.quickaction >= this.first_slice_idx 
+	                && this.quickaction < this.first_slice_idx+this.visible_slice_count) {
 
 	                next_active_slice = this.quickaction;
-	                angle = 2.0*PI*quickaction/(double)slice_count();
-	            } else if (distance > Config.global.theme.active_radius && this.slice_count() > 0 && distance < Config.global.activation_range) {
-	                next_active_slice = (int)(angle*slices.size/(2*PI) + 0.5) % this.slice_count();
+	                int n= this.quickaction - this.first_slice_idx;
+	                angle = 2.0*PI*n/(double)this.total_slice_count + this.first_slice_angle;
+	                
+	            } else if (distance > Config.global.theme.active_radius && this.total_slice_count > 0 
+                           && distance < Config.global.activation_range) {
+	                double a= angle-this.first_slice_angle;
+	                if (a < 0)
+	                    a= a + 2*PI;
+	                next_active_slice = (int)(a*this.total_slice_count/(2*PI) + 0.5) % this.total_slice_count;
+	                if (next_active_slice >= this.visible_slice_count)
+    	                next_active_slice = -1;
+    	            else {
+	                    next_active_slice = next_active_slice + this.first_slice_idx;
+	                    mouse_track= 1;
+	                }
 	            } else {
 	                next_active_slice = -1;
 	            }
@@ -270,10 +550,12 @@ public class PieRenderer : GLib.Object {
 	            this.set_highlighted_slice(next_active_slice);
 	        }
 
-            center.draw(frame_time, ctx, angle, distance);
+            center.draw(frame_time, ctx, angle, mouse_track);
 
-	        foreach (var slice in this.slices)
-		        slice.draw(frame_time, ctx, angle, distance);
+	        //foreach (var slice in this.slices)
+	        for (int i= 0; i < this.visible_slice_count; ++i) {
+	           this.slices[ i+this.first_slice_idx ].draw(frame_time, ctx, angle, mouse_track);
+		    }
 		}
     }
 
@@ -291,21 +573,219 @@ public class PieRenderer : GLib.Object {
 
     public void set_highlighted_slice(int index) {
         if (index != this.active_slice) {
-            if (index >= 0 && index < this.slice_count())
+            if (index >= this.first_slice_idx && index < this.first_slice_idx+this.visible_slice_count)
                 this.active_slice = index;
-            else if (this.quickaction >= 0)
+            else if (this.quickaction >= this.first_slice_idx && this.quickaction < this.first_slice_idx+this.visible_slice_count)
                 this.active_slice = this.quickaction;
             else
                 this.active_slice = -1;
 
-            SliceRenderer? active = (this.active_slice >= 0 && this.active_slice < this.slice_count()) ?
+            SliceRenderer? active = (this.active_slice >= 0 && this.active_slice < slices.size) ?
                                      this.slices[this.active_slice] : null;
 
             center.set_active_slice(active);
 
-            foreach (var slice in this.slices)
-                slice.set_active_slice(active);
+            //foreach (var slice in this.slices)
+            //    slice.set_active_slice(active);
+	        for (int i= 0; i < this.visible_slice_count; ++i) {
+	           this.slices[ i+this.first_slice_idx ].set_active_slice(active);
+		    }
         }
+    }
+    
+    private void set_show_mode(ShowPieMode show_mode) {
+    	//The index of the first visible slice 
+    	this.first_slice_idx= 0;
+    	//Angular position of the first visible slice 
+	    this.first_slice_angle= 0;
+   	
+   		int mult= 1;
+    	switch(show_mode) {
+    	    //half pie
+            case ShowPieMode.HPIE_LEFT:
+                mult= 2;
+                this.first_slice_angle= -PI/2;
+                break;
+            case ShowPieMode.HPIE_RIGHT:
+                mult= 2;
+                this.first_slice_angle= PI/2;
+                break;
+            case ShowPieMode.HPIE_TOP:
+                mult= 2;
+                break;
+            case ShowPieMode.HPIE_BOTTOM:
+                this.first_slice_angle= PI;
+                mult= 2;
+                break;
+
+            //cuarter pie
+            case ShowPieMode.CPIE_TOP_LEFT:
+                mult= 4;
+                break;
+            case ShowPieMode.CPIE_TOP_RIGHT:
+                this.first_slice_angle= PI/2;
+                mult= 4;
+                break;
+            case ShowPieMode.CPIE_BOT_LEFT:
+                this.first_slice_angle= -PI/2;
+                mult= 4;
+                break;
+            case ShowPieMode.CPIE_BOT_RIGHT:
+                this.first_slice_angle= PI;
+                mult= 4;
+                break;
+
+            default: 	//ShowPieMode.FULL_PIE or invalid values
+            	show_mode= ShowPieMode.FULL_PIE; 
+            	break;
+        }
+    	this.pie_show_mode= show_mode;
+    	//limit the number of visible slices
+   		int maxview= this.max_visible_slices / mult;
+    	//Number of visible slices
+    	this.visible_slice_count= (int)fmin(slices.size, maxview);
+    	//Number of slices in full pie (visible or not)
+    	this.total_slice_count= this.visible_slice_count*mult;
+    	if (mult > 1) {
+    	    this.total_slice_count -= mult;
+    	}
+       
+        //keep a copy of the original value since page up/down change it
+        original_visible_slice_count= visible_slice_count;
+    	
+        calc_key_navigation_pos();
+    }
+    
+    private void calc_key_navigation_pos() {
+   	    //calc slices index for keyboard navigation
+        
+        int a= this.first_slice_idx;
+        int b= this.first_slice_idx + this.visible_slice_count/4;
+        int c= this.first_slice_idx + this.visible_slice_count/2;
+        int d= this.first_slice_idx + (this.visible_slice_count*3)/4;
+        int e= this.first_slice_idx + this.visible_slice_count -1;
+    	switch(this.pie_show_mode) {
+    	    //half pie
+            case ShowPieMode.HPIE_LEFT:
+	            this.up_slice_idx=    a;
+                this.right_slice_idx= c;
+                this.down_slice_idx=  e;
+                this.left_slice_idx=  -1;    //no left slice, go up instead
+                break;
+            case ShowPieMode.HPIE_RIGHT:
+                this.down_slice_idx=  a;
+                this.left_slice_idx=  c;
+	            this.up_slice_idx=    e;
+	            this.right_slice_idx= -1;   //no right slice, go down instead
+                break;
+            case ShowPieMode.HPIE_TOP:
+                this.right_slice_idx= a;
+                this.down_slice_idx=  c;
+                this.left_slice_idx=  e;
+                this.up_slice_idx=    -1;    //no up slice, go left instead
+                break;
+            case ShowPieMode.HPIE_BOTTOM:
+                this.left_slice_idx=  a;
+	            this.up_slice_idx=    c;
+                this.right_slice_idx= e;
+                this.down_slice_idx=  -1;   //no down slice, go right instead
+                break;
+
+            //cuarter pie
+            case ShowPieMode.CPIE_TOP_LEFT:
+                this.right_slice_idx= a;
+                this.down_slice_idx=  e;
+                this.up_slice_idx=    -1;    //no up slice, go right instead
+                this.left_slice_idx=  -1;    //no left slice, go down instead
+                break;
+            case ShowPieMode.CPIE_TOP_RIGHT:
+                this.down_slice_idx=  a;
+                this.left_slice_idx=  e;
+                this.up_slice_idx=    -1;    //no up slice, go left instead
+                this.right_slice_idx= -1;    //no righ slice, go down instead
+                break;
+            case ShowPieMode.CPIE_BOT_LEFT:
+	            this.up_slice_idx=    a;
+                this.right_slice_idx= e;
+                this.down_slice_idx=  -1;    //no down slice, go right instead
+                this.left_slice_idx=  -1;    //no left slice, go up instead
+                break;
+            case ShowPieMode.CPIE_BOT_RIGHT:
+                this.left_slice_idx=  a;
+	            this.up_slice_idx=    e;
+                this.down_slice_idx=  -1;    //no down slice, go left instead
+                this.right_slice_idx= -1;    //no right slice, go up instead
+                break;
+
+            default: 	//ShowPieMode.FULL_PIE or invalid values
+                this.right_slice_idx= a;
+                this.down_slice_idx=  b;
+                this.left_slice_idx=  c;
+	            this.up_slice_idx=    d;
+            	break;
+        }
+    }
+
+
+   /////////////////////////////////////////////////////////////////////
+    /// keyboard navigation helper
+    /// move current position one slice towards the given extreme
+    /////////////////////////////////////////////////////////////////////
+    
+    private void move_active_slice(int extreme, int other_extreme ) {
+        int pos= this.active_slice;
+       
+        if (pos < 0 || pos == extreme) {
+            //no actual position or allready at the extreme
+            pos= extreme; //go to the extreme pos
+            
+        } else if (extreme == -1) {
+            //the extreme was eaten, just go away from the other_extreme
+            if (pos > other_extreme || other_extreme == 0) {
+                if (pos < this.visible_slice_count+this.first_slice_idx-1)
+                    pos++;
+            } else if (pos > this.first_slice_idx)
+                pos--;
+                
+        } else if (other_extreme == -1) {
+            //the other_extreme was eaten, just get closer to the extreme
+            if (pos < extreme)
+                pos++;
+            else if (pos > extreme)
+                pos--;
+
+        } else if (pos == other_extreme) {  
+            //both extremes are present            
+            //jump quickly form one extreme to the other
+            pos= extreme; //go to the extreme pos
+                
+        } else {
+            //both extremes are present            
+            //add or substract 1 to position in a circular manner
+            if (extreme > other_extreme) {
+                if (pos > other_extreme && pos < extreme)
+                    //other_extreme < pos < extreme
+                    pos= pos+1;
+                else
+                    pos= pos-1;
+            } else {
+                if (pos > extreme && pos < other_extreme)
+                    //extreme < pos < other_extreme
+                    pos= pos-1;
+                else
+                    pos= pos+1;
+            }
+                
+            if (pos < this.first_slice_idx)
+                pos= this.visible_slice_count-1+this.first_slice_idx;
+                
+            if (pos >= this.visible_slice_count+this.first_slice_idx)
+                pos= this.first_slice_idx;
+        }
+
+        this.set_highlighted_slice(pos);
+        
+        this.key_board_control = true;
     }
 }
 

--- a/src/renderers/pieWindow.vala
+++ b/src/renderers/pieWindow.vala
@@ -97,7 +97,8 @@ public class PieWindow : Gtk.Window {
         this.add_events(Gdk.EventMask.BUTTON_RELEASE_MASK |
                         Gdk.EventMask.KEY_RELEASE_MASK |
                         Gdk.EventMask.KEY_PRESS_MASK |
-                        Gdk.EventMask.POINTER_MOTION_MASK);
+                        Gdk.EventMask.POINTER_MOTION_MASK |
+                        Gdk.EventMask.SCROLL_MASK );
 
         // activate on left click
         this.button_release_event.connect ((e) => {
@@ -141,6 +142,15 @@ public class PieWindow : Gtk.Window {
             Gtk.grab_add(this);
             FocusGrabber.grab(this.get_window(), true, true, false);
         });
+        
+        this.scroll_event.connect((e) => {
+            if (e.direction == Gdk.ScrollDirection.UP)
+                this.renderer.select_prevpage();
+                
+            else if (e.direction == Gdk.ScrollDirection.DOWN)
+                this.renderer.select_nextpage();
+            return true;
+        });
 
         // draw the pie on expose
         this.draw.connect(this.draw_window);
@@ -153,7 +163,7 @@ public class PieWindow : Gtk.Window {
     public void load_pie(Pie pie) {
         this.renderer.load_pie(pie);
         this.set_window_position(pie);
-        this.set_size_request(renderer.size, renderer.size);
+        this.set_size_request(renderer.size_w, renderer.size_h);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -162,7 +172,6 @@ public class PieWindow : Gtk.Window {
 
     public void open() {
         this.realize();
-
         // capture the background image if there is no compositing
         if (!this.has_compositing) {
             int x, y, width, height;
@@ -194,12 +203,27 @@ public class PieWindow : Gtk.Window {
     /////////////////////////////////////////////////////////////////////
 
     public void get_center_pos(out int out_x, out int out_y) {
-        int x=0, y=0, width=0, height=0;
+        int x=0, y=0; //width=0, height=0;
         this.get_position(out x, out y);
-        this.get_size(out width, out height);
+        out_x = x + renderer.center_x;
+        out_y = y + renderer.center_y;
+    }
+    
+    private void get_mouse_position(out double mx, out double my) {
+        // get the mouse position
+        mx = 0.0;
+        my = 0.0;
+        Gdk.ModifierType mask;
 
-        out_x = x + width/2;
-        out_y = y + height/2;
+        var display = Gdk.Display.get_default();
+        var manager = display.get_device_manager();
+        GLib.List<weak Gdk.Device?> list = manager.list_devices(Gdk.DeviceType.MASTER);
+
+        foreach(var device in list) {
+            if (device.input_source != Gdk.InputSource.KEYBOARD) {
+                this.get_window().get_device_position_double(device, out mx, out my, out mask);
+            }
+        }
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -213,35 +237,26 @@ public class PieWindow : Gtk.Window {
             ctx.paint();
             ctx.set_operator (Cairo.Operator.OVER);
         } else {
+		    
             ctx.set_operator (Cairo.Operator.OVER);
             ctx.set_source_surface(background.surface, -1, -1);
             ctx.paint();
         }
 
         // align the context to the center of the PieWindow
-        ctx.translate(this.width_request*0.5, this.height_request*0.5);
+        ctx.translate(this.renderer.center_x, this.renderer.center_y);
 
         // get the mouse position
-        double mouse_x = 0.0, mouse_y = 0.0;
-        Gdk.ModifierType mask;
-
-        var display = Gdk.Display.get_default();
-        var manager = display.get_device_manager();
-        GLib.List<weak Gdk.Device?> list = manager.list_devices(Gdk.DeviceType.MASTER);
-
-        foreach(var device in list) {
-            if (device.input_source != Gdk.InputSource.KEYBOARD) {
-                this.get_window().get_device_position_double(device, out mouse_x, out mouse_y, out mask);
-            }
-        }
+        double mouse_x, mouse_y;
+        get_mouse_position( out mouse_x, out mouse_y );
 
         // store the frame time
         double frame_time = this.timer.elapsed();
         this.timer.reset();
 
         // render the Pie
-        this.renderer.draw(frame_time, ctx, (int)(mouse_x - this.width_request*0.5),
-                                            (int)(mouse_y - this.height_request*0.5));
+        this.renderer.draw(frame_time, ctx, (int)(mouse_x - this.renderer.center_x),
+                                            (int)(mouse_y - this.renderer.center_y));
 
         return true;
     }
@@ -251,7 +266,9 @@ public class PieWindow : Gtk.Window {
     /////////////////////////////////////////////////////////////////////
 
     private void activate_slice() {
+        message( "--activate_slice--" );
         if (!this.closing) {
+            message( "--closing--" );
             this.closing = true;
             this.on_closing();
             Gtk.grab_remove(this);
@@ -263,6 +280,7 @@ public class PieWindow : Gtk.Window {
             });
 
             GLib.Timeout.add((uint)(Config.global.theme.fade_out_time*1000), () => {
+                message( "--CLOSED--" );
                 this.closed = true;
                 this.on_closed();
                 this.destroy();
@@ -276,7 +294,9 @@ public class PieWindow : Gtk.Window {
     /////////////////////////////////////////////////////////////////////
 
     private void cancel() {
+        message( "--cancel--" );
         if (!this.closing) {
+            message( "--closing--" );
             this.closing = true;
             this.on_closing();
             Gtk.grab_remove(this);
@@ -284,6 +304,7 @@ public class PieWindow : Gtk.Window {
             this.renderer.cancel();
 
             GLib.Timeout.add((uint)(Config.global.theme.fade_out_time*1000), () => {
+                message( "--CLOSED--" );
                 this.closed = true;
                 this.on_closed();
                 this.destroy();
@@ -314,6 +335,10 @@ public class PieWindow : Gtk.Window {
             else if (Gdk.keyval_name(key) == "Down") this.renderer.select_down();
             else if (Gdk.keyval_name(key) == "Left") this.renderer.select_left();
             else if (Gdk.keyval_name(key) == "Right") this.renderer.select_right();
+            else if (Gdk.keyval_name(key) == "Page_Down") this.renderer.select_nextpage();
+            else if (Gdk.keyval_name(key) == "Page_Up") this.renderer.select_prevpage();
+            else if (Gdk.keyval_name(key) == "Tab") this.renderer.select_nextpage();
+            else if (Gdk.keyval_name(key) == "ISO_Left_Tab") this.renderer.select_prevpage();
             else if (Gdk.keyval_name(key) == "Alt_L") this.renderer.show_hotkeys = true;
             else {
                 int index = -1;

--- a/src/renderers/pieWindow.vala
+++ b/src/renderers/pieWindow.vala
@@ -266,9 +266,7 @@ public class PieWindow : Gtk.Window {
     /////////////////////////////////////////////////////////////////////
 
     private void activate_slice() {
-        message( "--activate_slice--" );
         if (!this.closing) {
-            message( "--closing--" );
             this.closing = true;
             this.on_closing();
             Gtk.grab_remove(this);
@@ -280,7 +278,6 @@ public class PieWindow : Gtk.Window {
             });
 
             GLib.Timeout.add((uint)(Config.global.theme.fade_out_time*1000), () => {
-                message( "--CLOSED--" );
                 this.closed = true;
                 this.on_closed();
                 this.destroy();
@@ -294,9 +291,7 @@ public class PieWindow : Gtk.Window {
     /////////////////////////////////////////////////////////////////////
 
     private void cancel() {
-        message( "--cancel--" );
         if (!this.closing) {
-            message( "--closing--" );
             this.closing = true;
             this.on_closing();
             Gtk.grab_remove(this);
@@ -304,7 +299,6 @@ public class PieWindow : Gtk.Window {
             this.renderer.cancel();
 
             GLib.Timeout.add((uint)(Config.global.theme.fade_out_time*1000), () => {
-                message( "--CLOSED--" );
                 this.closed = true;
                 this.on_closed();
                 this.destroy();

--- a/src/renderers/sliceRenderer.vala
+++ b/src/renderers/sliceRenderer.vala
@@ -196,7 +196,7 @@ public class SliceRenderer : GLib.Object {
     /// Draws all layers of the slice.
     /////////////////////////////////////////////////////////////////////
 
-    public void draw(double frame_time, Cairo.Context ctx, double angle, int mouse_track) {
+    public void draw(double frame_time, Cairo.Context ctx, double angle, int slice_track) {
 
         // update the AnimatedValues
         this.scale.update(frame_time);
@@ -220,7 +220,7 @@ public class SliceRenderer : GLib.Object {
 
         active = ((parent.active_slice >= 0) && (diff < PI/parent.total_slice_count));
 
-        if (mouse_track != 0) {
+        if (slice_track != 0) {
             double wobble = Config.global.theme.wobble*diff/PI*(1-diff/PI);
             if ((direction < angle && direction > angle - PI) || direction > PI+angle) {
                 this.wobble.reset_target(-wobble, Config.global.theme.transition_time*0.5);
@@ -240,7 +240,7 @@ public class SliceRenderer : GLib.Object {
 
 
 
-        max_scale = (mouse_track != 0 ? max_scale : 1.0/Config.global.theme.max_zoom);
+        max_scale = (slice_track != 0 ? max_scale : 1.0/Config.global.theme.max_zoom);
 
         if (fabs(this.scale.end - max_scale) > Config.global.theme.max_zoom*0.005)
             this.scale.reset_target(max_scale, Config.global.theme.transition_time);

--- a/src/renderers/sliceRenderer.vala
+++ b/src/renderers/sliceRenderer.vala
@@ -94,7 +94,14 @@ public class SliceRenderer : GLib.Object {
 
     public SliceRenderer(PieRenderer parent) {
         this.parent = parent;
+        this.reset_anim();
+    }
+        
+    /////////////////////////////////////////////////////////////////////
+    /// Put all AnimatedValues in their initial values
+    /////////////////////////////////////////////////////////////////////
 
+    public void reset_anim() {
         this.fade =   new AnimatedValue.linear(0.0, 0.0, Config.global.theme.transition_time);
         this.wobble = new AnimatedValue.linear(0.0, 0.0, Config.global.theme.transition_time);
         this.alpha =  new AnimatedValue.linear(0.0, 1.0, Config.global.theme.fade_in_time);
@@ -147,7 +154,7 @@ public class SliceRenderer : GLib.Object {
     }
 
     /////////////////////////////////////////////////////////////////////
-    /// Activaes the Action of this slice.
+    /// Activates the Action of this slice.
     /////////////////////////////////////////////////////////////////////
 
     public void activate() {
@@ -189,7 +196,7 @@ public class SliceRenderer : GLib.Object {
     /// Draws all layers of the slice.
     /////////////////////////////////////////////////////////////////////
 
-    public void draw(double frame_time, Cairo.Context ctx, double angle, double distance) {
+    public void draw(double frame_time, Cairo.Context ctx, double angle, int mouse_track) {
 
         // update the AnimatedValues
         this.scale.update(frame_time);
@@ -199,16 +206,21 @@ public class SliceRenderer : GLib.Object {
         this.fade_rotation.update(frame_time);
         this.wobble.update(frame_time);
 
-	    double direction = 2.0 * PI * position/parent.slice_count() + this.fade_rotation.val;
+	    double direction = 2.0 * PI * (position-parent.first_slice_idx)/parent.total_slice_count 
+                    	    + parent.first_slice_angle + this.fade_rotation.val;
 	    double max_scale = 1.0/Config.global.theme.max_zoom;
         double diff = fabs(angle-direction);
 
+        if (diff > 2 * PI)
+            diff = diff - 2 * PI;
+            
         if (diff > PI)
 	        diff = 2 * PI - diff;
 
-        active = ((parent.active_slice >= 0) && (diff < PI/parent.slice_count()));
 
-        if (parent.active_slice >= 0) {
+        active = ((parent.active_slice >= 0) && (diff < PI/parent.total_slice_count));
+
+        if (mouse_track != 0) {
             double wobble = Config.global.theme.wobble*diff/PI*(1-diff/PI);
             if ((direction < angle && direction > angle - PI) || direction > PI+angle) {
                 this.wobble.reset_target(-wobble, Config.global.theme.transition_time*0.5);
@@ -228,7 +240,7 @@ public class SliceRenderer : GLib.Object {
 
 
 
-        max_scale = (parent.active_slice >= 0 ? max_scale : 1.0/Config.global.theme.max_zoom);
+        max_scale = (mouse_track != 0 ? max_scale : 1.0/Config.global.theme.max_zoom);
 
         if (fabs(this.scale.end - max_scale) > Config.global.theme.max_zoom*0.005)
             this.scale.reset_target(max_scale, Config.global.theme.transition_time);
@@ -240,9 +252,9 @@ public class SliceRenderer : GLib.Object {
 
         // increase radius if there are many slices in a pie
         if (atan((Config.global.theme.slice_radius+Config.global.theme.slice_gap)
-          /(radius/Config.global.theme.max_zoom)) > PI/parent.slice_count()) {
+          /(radius/Config.global.theme.max_zoom)) > PI/parent.total_slice_count) {
             radius = (Config.global.theme.slice_radius+Config.global.theme.slice_gap)
-                     /tan(PI/parent.slice_count())*Config.global.theme.max_zoom;
+                     /tan(PI/parent.total_slice_count)*Config.global.theme.max_zoom;
         }
 
         // transform the context


### PR DESCRIPTION
* Added the option to auto-hide some slices when pies are open near a corner or a border (on by default). 
* Limit the number of shown slices. Scroll through them using mouse whell, tab or pg up/dwn.