### PR TITLE
change WM_CLASS so launchers can track windows properly

### DIFF
--- a/src/pies/pieManager.vala
+++ b/src/pies/pieManager.vala
@@ -89,6 +89,9 @@ public class PieManager : GLib.Object {
 
                 a_pie_is_active = true;
 
+                //change WM_CLASS so launchers can track windows properly
+                Gdk.set_program_class("gnome-pie-" + id);
+
                 var window = new PieWindow();
                 window.load_pie(pie);
 
@@ -275,7 +278,8 @@ public class PieManager : GLib.Object {
                 "Exec=%s -o %s\n".printf(Paths.executable, pie.id) +
                 "Encoding=UTF-8\n" +
                 "Type=Application\n" +
-                "Icon=%s\n".printf(pie.icon);
+                "Icon=%s\n".printf(pie.icon) +
+                "StartupWMClass=gnome-pie-%s\n".printf(pie.id);
 
             // create the launcher file
             string launcher = Paths.launchers + "/%s.desktop".printf(pie.id);


### PR DESCRIPTION
This change allow launchers to launch properly several gnome-pie with different IDs.
(Unity launcher hungs for a couple of seconds without this change when you have 2 or more gnome-pie items added: you open one gnome-pie item and "other" gnome-pie item is hilited).

** Remove all desktop files from .config (to be sure they are regenerated), remove gnome-pie items from the launcher,  logout-loguin and then add the new generated desktop files to the launcher.