### PR TITLE
Compatibility fixes for recent GNOME versions

### DIFF
--- a/src/actionGroups/devicesGroup.vala
+++ b/src/actionGroups/devicesGroup.vala
@@ -33,7 +33,7 @@ public class DevicesGroup : ActionGroup {
     public static GroupRegistry.TypeDescription register() {
         var description = new GroupRegistry.TypeDescription();
         description.name = _("Group: Devices");
-        description.icon = "harddrive";
+        description.icon = "drive-harddisk";
         description.description = _("Shows a Slice for each plugged in devices, like USB-Sticks.");
         description.id = "devices";
         return description;
@@ -82,7 +82,7 @@ public class DevicesGroup : ActionGroup {
 
     private void load() {
         // add root device
-        this.add_action(new UriAction(_("Root"), "harddrive", "file:///"));
+        this.add_action(new UriAction(_("Root"), "drive-harddisk", "file:///"));
 
         // add all other devices
         foreach(var mount in this.monitor.get_mounts()) {

--- a/src/actionGroups/menuGroup.vala
+++ b/src/actionGroups/menuGroup.vala
@@ -33,7 +33,7 @@ public class MenuGroup : ActionGroup {
     public static GroupRegistry.TypeDescription register() {
         var description = new GroupRegistry.TypeDescription();
         description.name = _("Group: Main menu");
-        description.icon = "gnome-main-menu";
+        description.icon = "start-here";
         description.description = _("Displays your main menu structure.");
         description.id = "menu";
         return description;

--- a/src/actionGroups/sessionGroup.vala
+++ b/src/actionGroups/sessionGroup.vala
@@ -33,7 +33,7 @@ public class SessionGroup : ActionGroup {
     public static GroupRegistry.TypeDescription register() {
         var description = new GroupRegistry.TypeDescription();
         description.name = _("Group: Session Control");
-        description.icon = "gnome-logout";
+        description.icon = "system-log-out";
         description.description = _("Shows a Slice for Shutdown, Reboot, and Hibernate.");
         description.id = "session";
         return description;
@@ -57,14 +57,14 @@ public class SessionGroup : ActionGroup {
 //        iface = GLib.Bus.get_proxy_sync(GLib.BusType.SESSION, "org.kde.ksmserver", "/KSMServer");
 //        iface = GLib.Bus.get_proxy_sync(GLib.BusType.SESSION, "org.freedesktop.ConsoleKit", "/org/freedesktop/ConsoleKit/Manager");
 
-        this.add_action(new AppAction(_("Shutdown"), "gnome-shutdown",
-            "dbus-send --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.RequestShutdown"));
+        this.add_action(new AppAction(_("Shutdown"), "system-shutdown",
+            "dbus-send --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Shutdown"));
 
-        this.add_action(new AppAction(_("Logout"), "gnome-session-logout",
+        this.add_action(new AppAction(_("Logout"), "system-log-out",
             "dbus-send --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Logout uint32:1"));
 
-        this.add_action(new AppAction(_("Reboot"), "gnome-session-reboot",
-            "dbus-send --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.RequestReboot"));
+        this.add_action(new AppAction(_("Reboot"), "view-refresh",
+            "dbus-send --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Reboot"));
     }
 
     // TODO: check for available interfaces --- these may work too:

--- a/src/actionGroups/windowListGroup.vala
+++ b/src/actionGroups/windowListGroup.vala
@@ -32,7 +32,7 @@ public class WindowListGroup : ActionGroup {
     public static GroupRegistry.TypeDescription register() {
         var description = new GroupRegistry.TypeDescription();
         description.name = _("Group: Window List");
-        description.icon = "gnome-window-manager";
+        description.icon = "preferences-system-windows";
         description.description = _("Shows a Slice for each of your opened Windows. Almost like Alt-Tab.");
         description.id = "window_list";
         return description;

--- a/src/gui/piePreviewAddSign.vala
+++ b/src/gui/piePreviewAddSign.vala
@@ -87,7 +87,7 @@ public class PiePreviewAddSign : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void load() {
-        this.icon = new Icon("add", 36);
+        this.icon = new Icon("list-add", 36);
     }
 
     /////////////////////////////////////////////////////////////////////

--- a/src/gui/piePreviewDeleteSign.vala
+++ b/src/gui/piePreviewDeleteSign.vala
@@ -85,7 +85,7 @@ public class PiePreviewDeleteSign : GLib.Object {
     /////////////////////////////////////////////////////////////////////
 
     public void load() {
-        this.icon = new Icon("stock_delete", PiePreviewDeleteSign.radius*2);
+        this.icon = new Icon("edit-delete", PiePreviewDeleteSign.radius*2);
     }
 
     /////////////////////////////////////////////////////////////////////

--- a/src/pies/defaultConfig.vala
+++ b/src/pies/defaultConfig.vala
@@ -26,11 +26,11 @@ namespace Pies {
     public void create_default_config() {
 
         // add a pie with playback controls
-        var multimedia = PieManager.create_persistent_pie(_("Multimedia"), "stock_media-play", new Trigger.from_string("<Control><Alt>m"));
-            multimedia.add_action(new KeyAction(_("Next Track"), "stock_media-next", "XF86AudioNext", true));
-            multimedia.add_action(new KeyAction(_("Stop"), "stock_media-stop", "XF86AudioStop"));
-            multimedia.add_action(new KeyAction(_("Previous Track"), "stock_media-prev", "XF86AudioPrev"));
-            multimedia.add_action(new KeyAction(_("Play/Pause"), "stock_media-play", "XF86AudioPlay"));
+        var multimedia = PieManager.create_persistent_pie(_("Multimedia"), "media-playback-start", new Trigger.from_string("<Control><Alt>m"));
+            multimedia.add_action(new KeyAction(_("Next Track"), "media-skip-forward", "XF86AudioNext", true));
+            multimedia.add_action(new KeyAction(_("Stop"), "media-playback-stop", "XF86AudioStop"));
+            multimedia.add_action(new KeyAction(_("Previous Track"), "media-skip-backward", "XF86AudioPrev"));
+            multimedia.add_action(new KeyAction(_("Play/Pause"), "media-playback-start", "XF86AudioPlay"));
 
         // add a pie with the users default applications
         var apps = PieManager.create_persistent_pie(_("Applications"), "applications-accessories", new Trigger.from_string("<Control><Alt>a"));
@@ -47,20 +47,20 @@ namespace Pies {
             bookmarks.add_group(new DevicesGroup(bookmarks.id));
 
         // add a pie with session controls
-        var session = PieManager.create_persistent_pie(_("Session"), "gnome-session-halt", new Trigger.from_string("<Control><Alt>q"));
+        var session = PieManager.create_persistent_pie(_("Session"), "system-log-out", new Trigger.from_string("<Control><Alt>q"));
             session.add_group(new SessionGroup(session.id));
 
         // add a pie with a main menu
-        var menu = PieManager.create_persistent_pie(_("Main Menu"), "alacarte", new Trigger.from_string("<Control><Alt>space"));
+        var menu = PieManager.create_persistent_pie(_("Main Menu"), "start-here", new Trigger.from_string("<Control><Alt>space"));
             menu.add_group(new MenuGroup(menu.id));
 
         // add a pie with window controls
-        var window = PieManager.create_persistent_pie(_("Window"), "gnome-window-manager", new Trigger.from_string("<Control><Alt>w"));
-            window.add_action(new KeyAction(_("Scale"), "top", "<Control><Alt>s"));
-            window.add_action(new KeyAction(_("Minimize"), "bottom", "<Alt>F9", true));
+        var window = PieManager.create_persistent_pie(_("Window"), "preferences-system-windows", new Trigger.from_string("<Control><Alt>w"));
+            window.add_action(new KeyAction(_("Scale"), "go-top", "<Control><Alt>s"));
+            window.add_action(new KeyAction(_("Minimize"), "go-bottom", "<Alt>F9", true));
             window.add_action(new KeyAction(_("Close"), "window-close", "<Alt>F4"));
-            window.add_action(new KeyAction(_("Maximize"), "window_fullscreen", "<Alt>F10"));
-            window.add_action(new KeyAction(_("Restore"), "window_nofullscreen", "<Alt>F5"));
+            window.add_action(new KeyAction(_("Maximize"), "view-fullscreen", "<Alt>F10"));
+            window.add_action(new KeyAction(_("Restore"), "view-restore", "<Alt>F5"));
 
         // save the configuration to file
         Pies.save();

--- a/src/utilities/config.vala
+++ b/src/utilities/config.vala
@@ -192,7 +192,7 @@ public class Config : GLib.Object {
 
         if (themes.size > 0) {
             if (current == "") {
-                current = "Unity";
+                current = "Adwaita";
                 warning("No theme specified! Using default...");
             }
             foreach (var t in themes) {


### PR DESCRIPTION
1. Update icon names to work with the default Adwaita icon theme.
2. Use standard D-Bus names to shutdown and reboot the system.
3. Use Adwaita theme by default.